### PR TITLE
hide SelectAll checkbox when there are no rows to select

### DIFF
--- a/src/datatables.Selectable.js
+++ b/src/datatables.Selectable.js
@@ -256,8 +256,13 @@
 
         this.oDTSettings.oApi._fnCallbackReg(this.oDTSettings, 'aoDrawCallback',
             function(){
-                if (that.$selectAll)
+                if (that.$selectAll) {
                     that.$selectAll.groupToggle('update');
+                    if (that.oTable.fnSettings().fnRecordsDisplay() == 0)
+                        that.$selectAll.hide();
+                    else
+                        that.$selectAll.show();
+                }
             }, 'SelectableDrawCallback');
 
         // Redraw the whole table without refiltering and resorting.


### PR DESCRIPTION
Hi, Basil.

It seems strange to display SelectAll checkbox when there are no rows to select(after filtering for example). So I suggest to hide this checkbox when there are no rows and to show it again if rows appears. 

Thanks,
Alex. 
